### PR TITLE
Change "proposals" to "reviews"

### DIFF
--- a/focus_areas/code_development.md
+++ b/focus_areas/code_development.md
@@ -30,20 +30,20 @@ Goal **Activity**:
   * Metric **Code_Changes_Lines**(Period): Aggregated number of lines touched in all changes
   (see [Code_Changes_Lines](../metrics/Code_Changes_Lines.md)).
 
-* Question **Proposals**: How many proposals for changes to the source code
+* Question **Reviews**: How many reviews to proposed changes to the source code
 are happening during a certain time period?
 
-  * Metric **Proposals**(Period): Number of new proposals for changes
+  * Metric **Reviews**(Period): Number of new review requests for changes
   to the source code
-  (see [Proposals](../metrics/Proposals.md)).
+  (see [Reviews](../metrics/Reviews.md)).
 
-  * Metric **Proposals_Accepted**(Period): Number of proposals for changes
-  to the source code that were accepted
-  (see [Proposals_Accepted](../metrics/Proposals_Accepted.md)).
+  * Metric **Reviews_Accepted**(Period): Number of reviews for changes
+  to the source code that ended accepting the change
+  (see [Reviews_Accepted](../metrics/Reviews_Accepted.md)).
 
-  * Metric **Proposals_Declined**(Period): Number of proposals for changes
-  to the source code that were declined
-  (see [Proposals_Declined](../metrics/Proposals_Declined.md)).
+  * Metric **Reviews_Declined**(Period): Number of reviews for changes
+  to the source code that ended declining the change
+  (see [Reviews_Declined](../metrics/Reviews_Declined.md)).
 
 
 * Question **Issues**: How many issues related to the source code
@@ -60,22 +60,22 @@ are happening during a certain time period?
 
 Goal **Efficiency**:
 
-* Question **Proposals**: How efficient is the project in considering proposals for changes,
-made during a certain time period?
+* Question **Reviews**: How efficient is the project in reviewing proposed
+ changes to the code, during a certain time period?
 
-  * Metric **Proposal_Duration**(Period): For how long proposed changes are discussed
-  before they are accepted.
-  * Metric **Proposals_Accepted**(Period): Number of proposals for changes
-  to the source code that were accepted
-  (see [Proposals_Accepted](../metrics/Proposals_Accepted.md)).
-  * Metric **Proposal_Participants**(Period): How many persons participated in the discussion
-  of proposals.
-  * Metric: **Proposal_Backlog**(Period): How many proposals are still undecided
-  (they were neither accepted nor declined)?
-  * Summary metric: **Proposal_Acceptance_Ratio**(Period): Which fraction of new proposals
-  are finally accepted?
-  * Summary metric: **Proposal_Throughput**(Period): How many proposals are decided
-  (either accepted or declined) with respect to the number of proposals submitted?
+  * Metric **Review_Duration**(Period): For how long proposed changes are
+  reviewed before they are accepted.
+  * Metric **Review_Acceptance**(Period): How many reviews end accepting
+  the code change.
+  * Metric **Review_Participants**(Period): How many persons participated in
+  reviews of code changes.
+  * Metric: **Review_Backlog**(Period): How many reviews are still undecided
+  (proposed changes were neither accepted nor declined)?
+  * Summary metric: **Review_Acceptance_Ratio**(Period): Which fraction of
+  new proposals for changes are finally accepted after a review process?
+  * Summary metric: **Review_Throughput**(Period): How many proposals for
+   changes are decided after code review
+   (either accepted or declined) with respect to the number of proposals submitted?
     
 * Question **Issues**: How efficient is the project in dealing with issues related to
 the source code, for issues proposed during a certain time period?
@@ -103,13 +103,12 @@ Goal | Question | Metric
 --- | --- | ---
 Activity | Changes | [Code_Changes](../metrics/Code_Changes.md)
 Activity | Changes | [Code_Changes_Lines](../metrics/Code_Changes_Lines.md)
-Activity | Proposals | [Proposals](../metrics/Proposals.md)
-Activity | Proposals | [Proposals_Accepted](../metrics/Proposals_Accepted.md)
-Activity | Proposals | [Proposals_Declined](../metrics/Proposals_Declined.md)
-Activity | Issues    | [Issues_New](../metrics/Issues_New.md)
-Activity | Issues    | [Issues_Active](../metrics/Issues_Active.md)
-Activity | Issues    | [Issues_Closed](../metrics/Issues_Closed.md)
-
+Activity | Issues  | [Issues_New](../metrics/Issues_New.md)
+Activity | Issues  | [Issues_Active](../metrics/Issues_Active.md)
+Activity | Issues  | [Issues_Closed](../metrics/Issues_Closed.md)
+Activity | Reviews | [Reviews](../metrics/Reviews.md)
+Activity | Reviews | [Reviews_Accepted](../metrics/Reviews_Accepted.md)
+Activity | Reviews | [Reviews_Declined](../metrics/Reviews_Declined.md)
 
 
 ## Legacy metrics and questions

--- a/metrics/Reviews.md
+++ b/metrics/Reviews.md
@@ -1,6 +1,6 @@
-# Proposals
+# Reviews
 
-New proposals for changes to the source code, during a certain period.
+New review requests for changes to the source code, during a certain period.
 
 ## Description
 
@@ -13,7 +13,7 @@ sending new versions of their proposals, until reviews are
 positive, and the code is accepted, or until it is decided that
 the proposal is declined.
 
-For example, "proposals" correspond to "pull requests" in the case of GitHub,
+For example, "reviews" correspond to "pull requests" in the case of GitHub,
 to "merge requests" in the case of GitLab, and to "code reviews"
 or in some contexts "changesets" in the case of Gerrit.
 
@@ -23,7 +23,7 @@ Mandatory:
 
 * Period of time. Start and finish date of the period. Default: forever.
 
-    Period during which proposals are considered.
+    Period during which reviews are considered.
     
 * Criteria for source code. Algorithm. Default: all files are source code.
 
@@ -34,14 +34,14 @@ Mandatory:
 
 Usual aggregators are:
 
-* Count. Total number of proposals during the period.
+* Count. Total number of reviews during the period.
 
 ## Specific description: GitHub
 
-In the case of GitHub, a proposal is defined as a "pull request",
+In the case of GitHub, a review is defined as a "pull request",
 as long as it proposes changes to source code files.
 
-The date of the proposal can be defined (for considering it in a period or not)
+The date of the review can be defined (for considering it in a period or not)
 as the date in which the pull request was submitted.
 
 ### GitHub parameters
@@ -50,10 +50,10 @@ None.
 
 ## Specific description: GitLab
 
-In the case of GitLab, a proposal is defined as a "merge request",
+In the case of GitLab, a review is defined as a "merge request",
 as long as it proposes changes to source code files.
 
-The date of the proposal can be defined (for considering it in a period or not)
+The date of the review can be defined (for considering it in a period or not)
 as the date in which the merge request was submitted.
 
 ### GitLab parameters
@@ -62,11 +62,11 @@ None.
 
 ## Specific description: Gerrit
 
-In the case of Gerrit, a proposal is defined as a "code review",
+In the case of Gerrit, a review is defined as a "code review",
 or in some contexts, a "changeset",
 as long as it proposes changes to source code files.
 
-The date of the proposal can be defined (for considering it in a period or not)
+The date of the review can be defined (for considering it in a period or not)
 as the date in which the code review was started by submitting a
 patchset for review.
 
@@ -79,10 +79,10 @@ None.
 
 * Volume of changes proposed to a project.
 
-    Proposals are a proxy for the activity in a project.
-    By counting proposals to change code in the set of repositories corresponding
+    Reviews are a proxy for the activity in a project.
+    By counting reviews to code changes in the set of repositories corresponding
     to a project, you can have an idea of the overall activity in
-    proposing changes to that project.
+    reviewing changes to that project.
     Of course, this metric is not the only one that should be
     used to track volume of coding activity.
 
@@ -105,7 +105,7 @@ Some useful visualizations are:
 * Count per group over time
 
 These could be represented as bar charts, with time running in the X axis.
-Each bar would represent proposals to change the code
+Each bar would represent reviews to change the code
 during a certain period (eg, a month).
 
 ## Reference Implementation
@@ -116,7 +116,7 @@ during a certain period (eg, a month).
 
 * [Grimoirelab](https://chaoss.github.io/grimoirelab). Enriched index for
 GitHub Pull Requests, GitLab Merge Requests,
-and Gerrit repositories is composed of one item per proposal,
+and Gerrit repositories is composed of one item per review,
 which makes it basically correspond to this metric when counted.
 The GitHub Pull Requests, GitLab Merge Requests, and Gerrit summary panels,
 available out of the box, provide exactly that.

--- a/metrics/Reviews_Accepted.md
+++ b/metrics/Reviews_Accepted.md
@@ -1,14 +1,14 @@
-# Proposals_Accepted
+# Reviews_Accepted
 
-Proposals for changes to the source code that were accepted
+Reviews for changes to the source code that ended accepting the change
 during a certain period.
 
 ## Description
 
-Proposals are defined as in [Proposals](Proposals.md).
-Accepted proposals are those that are finally merged into the code
-base of the project.
-Accepted proposals can be linked to one or more changes to the source
+Reviews are defined as in [Reviews](Reviews.md).
+Accepted reviews are those that end with the corresponding changes
+finally merged into the code base of the project.
+Accepted reviews can be linked to one or more changes to the source
 code, those corresponding to the changes proposed and finally merged.
 
 For example, in GitHub when a pull request is accepted, all the 
@@ -23,7 +23,7 @@ Mandatory:
 
 * Period of time. Start and finish date of the period. Default: forever.
 
-    Period during which accepted proposals are considered.
+    Period during which accepted reviews are considered.
     
 * Criteria for source code. Algorithm. Default: all files are source code.
 
@@ -34,15 +34,15 @@ Mandatory:
 
 Usual aggregators are:
 
-* Count. Total number of accepted proposals during the period.
+* Count. Total number of accepted reviews during the period.
 
 ## Specific description: GitHub
 
-In the case of GitHub, accepted proposals are defined as "pull requests
+In the case of GitHub, accepted reviews are defined as "pull requests
 whose changes are included in the git repository",
 as long as it proposes changes to source code files.
 
-Unfortunately, there are several ways of accepting proposals, not
+Unfortunately, there are several ways of accepting reviews, not
 all of them making it easy to identify that they were accepted.
 The easiest situation is when the pull request is accepted and
 merged (or rebased, or squashed and merged). In that case,
@@ -79,7 +79,7 @@ Mandatory:
 
 ## Specific description: GitLab
 
-In the case of GitLab, accepted proposals are defined as "merge requests
+In the case of GitLab, accepted reviews are defined as "merge requests
 whose changes are included in the git repository",
 as long as it proposes changes to source code files.
 
@@ -95,7 +95,7 @@ Mandatory:
 
 ## Specific description: Gerrit
 
-In the case of Gerrit, accepted proposals are defined as "changesets
+In the case of Gerrit, accepted reviews are defined as "changesets
 whose changes are included in the git repository",
 as long as they proposes changes to source code files.
 
@@ -113,8 +113,8 @@ None.
 
 * Volume of coding activity.
 
-    Accepted code proposals are a proxy for the activity in a project.
-    By counting accepted code proposals in the set of repositories corresponding
+    Accepted code reviews are a proxy for the activity in a project.
+    By counting accepted code reviews in the set of repositories corresponding
     to a project, you can have an idea of the overall coding activity in
     that project that leads to actual changes.
     Of course, this metric is not the only one that should be
@@ -138,7 +138,7 @@ Some useful visualizations are:
 * Count per group over time
 
 These could be represented as bar charts, with time running in the X axis.
-Each bar would represent accepted proposals to change the code
+Each bar would represent accepted reviews to change the code
 during a certain period (eg, a month).
 
 ## Reference Implementation

--- a/metrics/Reviews_Declined.md
+++ b/metrics/Reviews_Declined.md
@@ -1,12 +1,12 @@
-# Proposals_Declined
+# Reviews_Declined
 
-Proposals for changes to the source code that were declined
+Reviews for changes to the source code that ended declining the change
 during a certain period.
 
 ## Description
 
-Proposals are defined as in [Proposals](Proposals.md).
-Declined proposals are those that are finally closed without
+Reviews are defined as in [Reviews](Reviews.md).
+Declined reviews are those that are finally closed without
 being merged into the code base of the project.
 
 For example, in GitHub when a pull request is closed without
@@ -15,7 +15,7 @@ in the git repository, it can be considered to be declined
 (but see detailed discussion below). The same can be said of
 GitLab merge requests. In the case of Gerrit, code reviews
 can be formally "abandoned", which is the way of detecting
-declined proposals in this system. 
+declined reviews in this system. 
 
 ### Parameters
 
@@ -23,7 +23,7 @@ Mandatory:
 
 * Period of time. Start and finish date of the period. Default: forever.
 
-    Period during which declined proposals are considered.
+    Period during which declined reviews are considered.
     
 * Criteria for source code. Algorithm. Default: all files are source code.
 
@@ -34,16 +34,16 @@ Mandatory:
 
 Usual aggregators are:
 
-* Count. Total number of declined proposals during the period.
+* Count. Total number of declined reviews during the period.
 
 ## Specific description: GitHub
 
-In the case of GitHub, accepted proposals are defined as "pull requests
+In the case of GitHub, accepted reviews are defined as "pull requests
 that are closed with their changes not being included in the git repository",
 as long as it proposes changes to source code files.
 
 See the discussion in the specific description for GitHub in
-[Proposals_Accepted](Proposals_Accepted.md), since it applies here
+[Reviews_Accepted](Reviews_Accepted.md), since it applies here
 as well.
 
 ### GitHub parameters
@@ -57,7 +57,7 @@ Mandatory:
 
 ## Specific description: GitLab
 
-In the case of GitLab, accepted proposals are defined as "merge requests
+In the case of GitLab, accepted reviews are defined as "merge requests
 that are closed with their changes not being included in the git repository",
 as long as it proposes changes to source code files.
 
@@ -74,7 +74,7 @@ Mandatory:
 
 ## Specific description: Gerrit
 
-In the case of Gerrit, declined proposals are defined as "changesets
+In the case of Gerrit, declined reviews are defined as "changesets
 absndoned", as long as they propose changes to source code files.
 
 [ Details to be done ]
@@ -89,8 +89,8 @@ None.
 
 * Volume of coding activity.
 
-    Declined code proposals are a proxy for the activity in a project.
-    By counting declined code proposals in the set of repositories corresponding
+    Declined code reviews are a proxy for the activity in a project.
+    By counting declined code reviews in the set of repositories corresponding
     to a project, you can have an idea of the overall coding activity in
     that project that did not lead to actual changes.
     Of course, this metric is not the only one that should be
@@ -114,7 +114,7 @@ Some useful visualizations are:
 * Count per group over time
 
 These could be represented as bar charts, with time running in the X axis.
-Each bar would represent declined proposals during a certain period
+Each bar would represent declined reviews during a certain period
 (eg, a month).
 
 ## Reference Implementation

--- a/metrics/name_changes.md
+++ b/metrics/name_changes.md
@@ -1,0 +1,17 @@
+# Dictionary of changes in metrics names
+
+This document intends to keep track of changes in metrics names,
+to easy transitions, and mapping from "old" names to current ones.
+
+| Old name                  | New name                | Date of change | Comments             |
+|---------------------------|-------------------------|----------------|----------------------|
+| Proposals                 | Reviews                 | 2019-04        | Proposals to reviews |
+| Proposals_Accepted        | Reviews_Accepted        | 2019-04        | Proposals to reviews |
+| Proposals_Declined        | Reviews_Declined        | 2019-04        | Proposals to reviews |
+| Proposals_Duration        | Reviews_Duration        | 2019-04        | Proposals to reviews |
+| Proposals_Acceptance      | Reviews_Acceptance      | 2019-04        | Proposals to reviews |
+| Proposals_Participants    | Reviews_Participants    | 2019-04        | Proposals to reviews |
+| Proposals_Backlog         | Reviews_Backlog         | 2019-04        | Proposals to reviews |
+| Proposal_Acceptance_Ratio | Review_Acceptance_Ratio | 2019-04        | Proposals to reviews |
+| Proposal_Throughput       | Review_Throughput       | 2019-04        | Proposals to reviews |
+


### PR DESCRIPTION
The name "reviews" seems much easier to understand that "proposals", so we're changing all occurrences of "proposals" to "reviews".

Closes: #110