### PR TITLE
Display Focus Area overview as a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ Our key focus areas for 2019 are summarized [here](ROADMAP.md).
 
 ## Metrics
 
-The metrics dealt with in this focus group are organized in focus areas:
+The evolution metrics dealt with in this focus group are organized in focus areas:
 
-* Growth Maturity and Decline
-  * [Code Development](focus_areas/code_development.md)
-  * [Community Growth](focus_areas/community_growth.md)
-  * [Issue Resolution](focus_areas/issue_resolution.md)
+Focus Area | Description
+--- | ---
+[Code Development](./focus_areas/code_development.md) | Scope: Aspects related to how the source code changes over time, and the mechanisms that the project has to perform and control those changes.
+[Community Growth](./focus_areas/community_growth.md) | Goal: Identify the size of the project community and whether it is growing, shrinking, or staying the same.
+[Issue Resolution](./focus_areas/issue_resolution.md) | Goal: Identify how effective the community is at addressing issues identified by community participants.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Our key focus areas for 2019 are summarized [here](ROADMAP.md).
 
 ## Metrics
 
-The evolution metrics dealt with in this focus group are organized in focus areas:
+The evolution metrics dealt with in this working group are organized in focus areas:
 
 Focus Area | Description
 --- | ---

--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -1,6 +1,6 @@
 # Focus Areas
 
-The evolution metrics dealt with in this focus group are organized in focus areas:
+The evolution metrics dealt with in this working group are organized in focus areas:
 
 Focus Area | Description
 --- | ---

--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -1,0 +1,9 @@
+# Focus Areas
+
+The evolution metrics dealt with in this focus group are organized in focus areas:
+
+Focus Area | Description
+--- | ---
+[Code Development](./code_development.md) | Scope: Aspects related to how the source code changes over time, and the mechanisms that the project has to perform and control those changes.
+[Community Growth](./community_growth.md) | Goal: Identify the size of the project community and whether it is growing, shrinking, or staying the same.
+[Issue Resolution](./issue_resolution.md) | Goal: Identify how effective the community is at addressing issues identified by community participants.

--- a/focus_areas/code_development.md
+++ b/focus_areas/code_development.md
@@ -24,7 +24,7 @@ to time periods.
 
 Goal **Activity**:
 
-* Question **Changes**: How many changes are happening to the source code, during a certain time period? 
+* Question **Changes**: How many changes are happening to the source code, during a certain time period?
   * Metric **Code_Changes**(Period): Number of changes to the source code
   (see [Code_Changes](../metrics/Code_Changes.md)).
   * Metric **Code_Changes_Lines**(Period): Aggregated number of lines touched in all changes
@@ -76,7 +76,7 @@ made during a certain time period?
   are finally accepted?
   * Summary metric: **Proposal_Throughput**(Period): How many proposals are decided
   (either accepted or declined) with respect to the number of proposals submitted?
-    
+
 * Question **Issues**: How efficient is the project in dealing with issues related to
 the source code, for issues proposed during a certain time period?
 

--- a/focus_areas/code_development.md
+++ b/focus_areas/code_development.md
@@ -24,7 +24,7 @@ to time periods.
 
 Goal **Activity**:
 
-* Question **Changes**: How many changes are happening to the source code, during a certain time period?
+* Question **Changes**: How many changes are happening to the source code, during a certain time period? 
   * Metric **Code_Changes**(Period): Number of changes to the source code
   (see [Code_Changes](../metrics/Code_Changes.md)).
   * Metric **Code_Changes_Lines**(Period): Aggregated number of lines touched in all changes


### PR DESCRIPTION
The idea of this pull request is to display focus areas as a table with a description of the focus areas. This is supposed to help someone coming to the repository to know what each focus area is about.

Further, this pull request replicates the table in a README for the /focus-area dirctory, so that it is more user friendly when someone looks through the structure of the repo.