### PR TITLE
[analyze-script] Add markdown support to analyze script

### DIFF
--- a/bin/analyze
+++ b/bin/analyze
@@ -153,7 +153,7 @@ def parse_args():
     parser.add_argument("-o", "--output-formats",
                         default=['json'],
                         nargs='+',
-                        choices=['json', 'pdf', 'images'],
+                        choices=['markdown', 'json', 'pdf', 'images'],
                         help="Possible options: %(choices)s (any combination)")
 
     parser.add_argument("-d", "--debug",

--- a/implementations/generate_output.py
+++ b/implementations/generate_output.py
@@ -27,9 +27,11 @@ import logging
 from fpdf import FPDF
 
 
+MD_FILE = 'report.markdown'
 PDF_FILE = 'report.pdf'
 JSON_FILE = 'report.json'
 IMAGES_DIR = 'images'
+MD_REPORT_TITLE = 'Metrics Report'
 PDF_REPORT_TITLE = 'Metrics Report'
 
 logger = logging.getLogger(__name__)
@@ -62,6 +64,7 @@ class GenerateOutput():
         self.period = period
 
         self.generate_options = {
+            'markdown': self._generate_markdown,
             'json': self._generate_json,
             'pdf': self._generate_pdf,
             'images': self._generate_images
@@ -128,6 +131,38 @@ class GenerateOutput():
                           + "_".join(str(result['metric']).split()) + '.png', w=200)
 
         pdf.output(self.write_to + '/' + PDF_FILE, 'F')
+
+    def _generate_markdown(self):
+        """
+        Generates a markdown report with results of the compute
+        method as well as an image of the resultant plot.
+
+        Creates MD_FILE.
+        """
+
+        logger.info("Generating %s" % MD_FILE)
+        template = "# {}\n\n".format(MD_REPORT_TITLE)
+
+        self._generate_images()
+
+        for category, results_ in self.results.items():
+            for result in results_:
+
+                template += "## " + str(result['metric']) + '\n'
+
+                txt = \
+                    "The value of the metric is:\n" \
+                    + "{}. \n".format(result['value'])
+
+                template += txt
+
+                embed_img = '![](../' + self.write_to + '/' + IMAGES_DIR + '/' \
+                            + "_".join(str(result['metric']).split()) + '.png)'
+
+                template += embed_img + "\n\n"
+
+        with open(self.write_to + '/' + MD_FILE, 'w') as f:
+            f.write(template)
 
     def _generate_json(self):
         """

--- a/implementations/tests/tests_df/test_open_issue_age_github.py
+++ b/implementations/tests/tests_df/test_open_issue_age_github.py
@@ -41,7 +41,7 @@ class TestOpenIssueAgeGitHub(unittest.TestCase):
         """
 
         open_issue_age = OpenIssueAgeGitHub(self.items)
-        expected_mean = 1132.0
+        expected_mean = 1179.0
         mean_age = open_issue_age.compute()
         self.assertEqual(expected_mean, mean_age)
 


### PR DESCRIPTION
This patch adds an option to generate a 
markdown script post analysis of metrics. 
