### PR TITLE
Update focus area titles and goals

### DIFF
--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -2,8 +2,8 @@
 
 The evolution metrics dealt with in this working group are organized in focus areas:
 
-Focus Area | Description
+Focus Area | Goal
 --- | ---
-[Code Development](./code_development.md) | Scope: Aspects related to how the source code changes over time, and the mechanisms that the project has to perform and control those changes.
-[Community Growth](./community_growth.md) | Goal: Identify the size of the project community and whether it is growing, shrinking, or staying the same.
-[Issue Resolution](./issue_resolution.md) | Goal: Identify how effective the community is at addressing issues identified by community participants.
+[Code Development Activity](./code_development_activity.md) | Learn about the types and frequency of activities involved in developing code.
+[Code Development Efficiency](./code_development_efficiency.md) | Learn how efficiently activities around code development get resolved.
+[Code Development Process Quality](./code_development_quality.md) | Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).

--- a/focus_areas/code_development_activity.md
+++ b/focus_areas/code_development_activity.md
@@ -1,0 +1,3 @@
+# Focus Area: Code Development Activity
+
+Goal: Learn about the types and frequency of activities involved in developing code.

--- a/focus_areas/code_development_efficiency.md
+++ b/focus_areas/code_development_efficiency.md
@@ -1,0 +1,3 @@
+# Focus Area: Code Development Efficiency
+
+Goal:  Learning how efficiently activities around code development get resolved.

--- a/focus_areas/code_development_process_quality.md
+++ b/focus_areas/code_development_process_quality.md
@@ -1,0 +1,3 @@
+# Focus Area: Code Development Process Activity
+
+Goal: Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).


### PR DESCRIPTION
This PR updates the links to the new focus areas that we discussed in the previous meeting on 9/26/19. I elected to leave these focus areas empty for now (bar the goals we outlined) so that we could decide as a group where each of the current metrics might go.

Signed-off-by: Carter Landis <ccarterlandis@gmail.com>