### PR TITLE
Add released metrics to new focus areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Focus Area | Goal
 --- | ---
 [Code Development Activity](./code_development_activity.md) | Learn about the types and frequency of activities involved in developing code.
 [Code Development Efficiency](./code_development_efficiency.md) | Learn how efficiently activities around code development get resolved.
-[Code Development Process Quality](./code_development_quality.md) | Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+[Code Development Process Quality](./code_development_process_quality.md) | Learn about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+[Issue Resolution](./issue_resolution.md) | Identify how effective the community is at addressing issues identified by community participants.
 
 Please note that the work in the focus areas is still in progress.
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ The evolution metrics dealt with in this working group are organized in focus ar
 
 Focus Area | Goal
 --- | ---
-[Code Development Activity](./code_development_activity.md) | Learn about the types and frequency of activities involved in developing code.
-[Code Development Efficiency](./code_development_efficiency.md) | Learn how efficiently activities around code development get resolved.
-[Code Development Process Quality](./code_development_process_quality.md) | Learn about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
-[Issue Resolution](./issue_resolution.md) | Identify how effective the community is at addressing issues identified by community participants.
+[Code Development Activity](./focus_areas/code_development_activity.md) | Learn about the types and frequency of activities involved in developing code.
+[Code Development Efficiency](./focus_areas/code_development_efficiency.md) | Learn how efficiently activities around code development get resolved.
+[Code Development Process Quality](./focus_areas/code_development_process_quality.md) | Learn about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+[Issue Resolution](./focus_areas/issue_resolution.md) | Identify how effective the community is at addressing issues identified by community participants.
 
 Please note that the work in the focus areas is still in progress.
 

--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -6,4 +6,5 @@ Focus Area | Goal
 --- | ---
 [Code Development Activity](./code_development_activity.md) | Learn about the types and frequency of activities involved in developing code.
 [Code Development Efficiency](./code_development_efficiency.md) | Learn how efficiently activities around code development get resolved.
-[Code Development Process Quality](./code_development_quality.md) | Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+[Code Development Process Quality](./code_development_process_quality.md) | Learn about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+[Issue Resolution](./issue_resolution.md) | Identify how effective the community is at addressing issues identified by community participants.

--- a/focus_areas/code_development_activity.md
+++ b/focus_areas/code_development_activity.md
@@ -1,3 +1,23 @@
 # Focus Area: Code Development Activity
 
 Goal: Learn about the types and frequency of activities involved in developing code.
+
+Name | Question
+--- | ---
+[Code Changes](../metrics/Code_Changes.md) | What changes were made to the source code during a specified period?
+[Code Changes Lines](../metrics/Code_Changes_Lines.md) | What is the sum of the number of lines touched (lines added plus lines removed) in all changes to the source code during a certain period?
+
+**Disclaimer:**
+The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
+
+**Tooling:**
+The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
+
+**Background:**
+The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
+
+**How to contribute:**
+- To advance the document, fork the repo, make your changes and create a pull request.
+- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
+
+[issue]: https://github.com/chaoss/evolution/issues

--- a/focus_areas/code_development_efficiency.md
+++ b/focus_areas/code_development_efficiency.md
@@ -1,3 +1,24 @@
 # Focus Area: Code Development Efficiency
 
 Goal:  Learning how efficiently activities around code development get resolved.
+
+Name | Question
+--- | ---
+[Reviews Accepted](../metrics/Reviews_Accepted.md) | How many accepted reviews are present in a code change? 
+[Reviews Declined](../metrics/Reviews_Declined.md) | What reviews of code changes ended up declining the change during a certain period?
+[Reviews Duration](../metrics/Reviews_Duration.md) | What is the duration of time between the moment a code review starts and moment it is accepted?
+
+**Disclaimer:**
+The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
+
+**Tooling:**
+The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
+
+**Background:**
+The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
+
+**How to contribute:**
+- To advance the document, fork the repo, make your changes and create a pull request.
+- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
+
+[issue]: https://github.com/chaoss/evolution/issues

--- a/focus_areas/code_development_process_quality.md
+++ b/focus_areas/code_development_process_quality.md
@@ -1,3 +1,22 @@
-# Focus Area: Code Development Process Activity
+# Focus Area: Code Development Process Quality
 
 Goal: Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+
+Name | Question
+--- | ---
+[Reviews](../metrics/Reviews.md) | What new review requests for changes to the source code occurred during a certain period?
+
+**Disclaimer:**
+The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
+
+**Tooling:**
+The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
+
+**Background:**
+The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
+
+**How to contribute:**
+- To advance the document, fork the repo, make your changes and create a pull request.
+- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
+
+[issue]: https://github.com/chaoss/evolution/issues

--- a/focus_areas/issue_resolution.md
+++ b/focus_areas/issue_resolution.md
@@ -1,18 +1,15 @@
-## Issue Resolution
+# Focus Area: Issue Resolution
 
 Goal: Identify how effective the community is at addressing issues identified by community participants.
 
-Metric | Question
+Name | Question
 --- | ---
-[Open Issues](../metrics/issues-open.md) | What is the number of open issues?
-[Closed Issues](../metrics/issues-closed.md) | What is the number of closed issues?
-[Open Issue Age](../metrics/issues-open-age.md) | What is the the age of open issues?
-[Issue Response Time](../metrics/issues-maintainer-response-duration.md) | What is the duration of time for a first response to an issue?
-[Closed Issue Resolution Duration](../metrics/issues-closed-resolution-duration.md) | What is the duration of time for issues to be resolved?
-[Issue Resolution Efficiency](../metrics/issues-closed-resolution-efficiency.md) |  What is the ratio of closed issues/number of abandoned issues?
+[Issues New](../metrics/Issues_New.md) | What are the number of new issues created during a certain period?
+[Issues Active](../metrics/Issues_Active.md) | What is the count of issues that showed activity during a certain period?
+[Issues Closed](../metrics/Issues_Closed.md) | What is the count of issues that were closed during a certain period?
 
 **Disclaimer:**
-The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Growth-Maturity-Decline.
+The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
 
 **Tooling:**
 The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
@@ -24,4 +21,4 @@ The name/question pairs have been identified based CHAOSS-related outreach activ
 - To advance the document, fork the repo, make your changes and create a pull request.
 - To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
 
-[issue]: https://github.com/chaoss/wg-gmd/issues
+[issue]: https://github.com/chaoss/evolution/issues

--- a/focus_areas/templates/question_template.md
+++ b/focus_areas/templates/question_template.md
@@ -1,3 +1,7 @@
+## Title
+
+## Question
+
 ## Description
 
 ## Objectives
@@ -15,7 +19,7 @@
 
 ### Data Collection Strategies (optional)
 
-## Success Metrics (optional)
+### Success Metrics (optional)
 
 ## Resources
 - links to external literature, etc

--- a/focus_areas/templates/question_template.md
+++ b/focus_areas/templates/question_template.md
@@ -1,6 +1,6 @@
-## Title
+# Title
 
-## Question
+**Question**
 
 ## Description
 

--- a/focus_areas/templates/question_template.md
+++ b/focus_areas/templates/question_template.md
@@ -1,37 +1,21 @@
-# [Area of Analysis]: [Focal Concern]
+## Description
 
-**Question:** placeholder for a variety of channels (choice?)
+## Objectives
 
+## Implementation
 
-## 1. Description
+### Filters (optional)
 
-_This section provides a rationale for why this question is important to growth maturity and decline._
-_Example for how to use this template: [Documentation](./resources/project_places-documentation.md)_
+### Visualizations (optional)
 
-## 2. Sample Objectives
+### Tools providing the metric (optional)
+- formerly: "known or sample implementations"
+- Metric must be currently deployed/available, in contrast to a tool having the "potential" to provide the metric
+- provide direct link to implementation/documentation, if applicable
 
-- _This section provides a list of reasons a community wants to assess this question_
--
+### Data Collection Strategies (optional)
 
+## Success Metrics (optional)
 
-## 3. Sample Strategies
-
-- _This section provides a list of methods available for answering the question._
--
-
-
-## 4. Sample Success Metrics
-_Qualitative_
-
-- _This section provides detailed instructions for how to execute the above listed methods and evaluate the results_
--
-
-_Quantitative_
-
-- _This section provides detailed instructions for how to execute the above listed quantitative methods and evaluate the results_
--
-
-
-## 5. Resources
-
-- _This section provides a list of resources and references_
+## Resources
+- links to external literature, etc

--- a/focus_areas/templates/question_template.md
+++ b/focus_areas/templates/question_template.md
@@ -1,25 +1,29 @@
-# Title
+# {Name of Metric}
 
-**Question**
+Question: _____
 
 ## Description
+A description of what the metric is and what it captures.
+The first few sentences should match the description in the [metrics list](../activity-metrics-list.md).
 
 ## Objectives
+Answer the question for why someone wants to measure this metric and what can be known with it.
 
 ## Implementation
+Provide details on how to measure the metric, collect the data, and analyze it. The following sub-headings are optional but help to structure the different aspects of implementation.
 
 ### Filters (optional)
+Include a Filter
 
 ### Visualizations (optional)
+Include visualizations such as screenshot of the metric. There may be many more visualizations for this metric, we only want to provide a flavor for what this metric is about.
 
-### Tools providing the metric (optional)
-- formerly: "known or sample implementations"
-- Metric must be currently deployed/available, in contrast to a tool having the "potential" to provide the metric
-- provide direct link to implementation/documentation, if applicable
+### Tools Providing the Metric (optional)
+Metric must be currently deployed/available, in contrast to a tool having the "potential" to provide the metric. Provide direct link to implementation/documentation, if applicable
 
-### Data Collection Strategies (optional)
+### Data Collection Strategies (Optional)
+If there are several different ways to collect data for this metric, list them here. 
+This may include expressing a metric in different ways.
 
-### Success Metrics (optional)
-
-## Resources
-- links to external literature, etc
+## References
+Blog posts, websites, academic papers, or books that mention the metric and provide more background.


### PR DESCRIPTION
This patch adds the metrics defined in the first formal metrics release
to their corresponding new focus areas. It also fixes a broken link in the
`focus_areas` README and updates the metric question template.

Please note that in this patch, **no actual metrics content has been changed**: barring typos or broken links, this patch solely reorganizes already released metrics.

Signed-off-by: Carter Landis <ccarterlandis@gmail.com>