### PR TITLE
[Licensing] Add licensing and rearrange a few imports

### DIFF
--- a/implementations/code_df/code_changes_git.py
+++ b/implementations/code_df/code_changes_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.code_df.commit_git import CommitGit

--- a/implementations/code_df/code_changes_lines_git.py
+++ b/implementations/code_df/code_changes_lines_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.code_df.commit_git import CommitGit

--- a/implementations/code_df/commit_git.py
+++ b/implementations/code_df/commit_git.py
@@ -1,5 +1,26 @@
-from implementations.code_df.conditions import Naive, Commit
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from implementations.code_df.metric import Metric
+from implementations.code_df.conditions import Naive, Commit
 from implementations.code_df.utils import str_to_date
 
 
@@ -19,6 +40,10 @@ class CommitGit(Metric):
 
     :param is_code:  list of CodeCondition objects
         It is used to determine what comprises source code.
+
+    :param conds: list of Commit sub-class objects.
+        Used to add restrictions on which commits are
+        included in the analysis.
         """
 
     def __init__(self, items, date_range=(None, None),

--- a/implementations/code_df/conditions.py
+++ b/implementations/code_df/conditions.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 """
 Conditions for filtering in or out some items coming from Perceval.
 

--- a/implementations/code_df/issue_github.py
+++ b/implementations/code_df/issue_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from implementations.code_df.metric import Metric
 from implementations.code_df.utils import str_to_date
 

--- a/implementations/code_df/issues_closed_github.py
+++ b/implementations/code_df/issues_closed_github.py
@@ -1,7 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
-from implementations.code_df.utils import read_json_file
 from implementations.code_df.issue_github import IssueGitHub
+from implementations.code_df.utils import read_json_file
 
 
 class IssuesClosedGitHub(IssueGitHub):

--- a/implementations/code_df/pullrequest_github.py
+++ b/implementations/code_df/pullrequest_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from implementations.code_df.metric import Metric
 from implementations.code_df.utils import str_to_date
 

--- a/implementations/code_df/reviews_accepted_github.py
+++ b/implementations/code_df/reviews_accepted_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.code_df.pullrequest_github import PullRequestGitHub

--- a/implementations/code_df/reviews_declined_github.py
+++ b/implementations/code_df/reviews_declined_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.code_df.pullrequest_github import PullRequestGitHub

--- a/implementations/code_df/reviews_duration_github.py
+++ b/implementations/code_df/reviews_duration_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.code_df.pullrequest_github import PullRequestGitHub

--- a/implementations/code_df/reviews_github.py
+++ b/implementations/code_df/reviews_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.code_df.pullrequest_github import PullRequestGitHub

--- a/implementations/code_df/utils.py
+++ b/implementations/code_df/utils.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import datetime
 import json
 

--- a/implementations/scripts/code_changes_git.py
+++ b/implementations/scripts/code_changes_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.scripts.commit_git import CommitGit

--- a/implementations/scripts/code_changes_lines_git.py
+++ b/implementations/scripts/code_changes_lines_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.scripts.commit_git import CommitGit

--- a/implementations/scripts/commit_git.py
+++ b/implementations/scripts/commit_git.py
@@ -1,5 +1,26 @@
-from implementations.scripts.conditions import Naive, Commit
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from implementations.scripts.metric import Metric
+from implementations.scripts.conditions import Naive, Commit
 from implementations.scripts.utils import str_to_date
 
 
@@ -20,6 +41,10 @@ class CommitGit(Metric):
 
     :param is_code:  list of CodeCondition objects
         It is used to determine what comprises source code.
+
+    :param conds: list of Commit sub-class objects.
+        Used to add restrictions on which commits are
+        included in the analysis.
         """
 
     def __init__(self, items, date_range=(None, None),

--- a/implementations/scripts/conditions.py
+++ b/implementations/scripts/conditions.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 """
 Conditions for filtering in or out some items coming from Perceval.
 

--- a/implementations/scripts/metric.py
+++ b/implementations/scripts/metric.py
@@ -1,3 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
 
 
 class Metric():

--- a/implementations/scripts/pullrequest_github.py
+++ b/implementations/scripts/pullrequest_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from implementations.scripts.metric import Metric
 from implementations.scripts.utils import str_to_date
 

--- a/implementations/scripts/reviews_accepted_github.py
+++ b/implementations/scripts/reviews_accepted_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.scripts.pullrequest_github import PullRequestGitHub

--- a/implementations/scripts/reviews_declined_github.py
+++ b/implementations/scripts/reviews_declined_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.scripts.pullrequest_github import PullRequestGitHub

--- a/implementations/scripts/reviews_github.py
+++ b/implementations/scripts/reviews_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 
 from implementations.scripts.pullrequest_github import PullRequestGitHub

--- a/implementations/scripts/utils.py
+++ b/implementations/scripts/utils.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import datetime
 import json
 

--- a/implementations/tests/tests/test_code_changes_git.py
+++ b/implementations/tests/tests/test_code_changes_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import json
 import unittest
 

--- a/implementations/tests/tests/test_code_changes_lines_git.py
+++ b/implementations/tests/tests/test_code_changes_lines_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests/test_commit_git.py
+++ b/implementations/tests/tests/test_commit_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import datetime
 import unittest
 import json

--- a/implementations/tests/tests/test_conditions.py
+++ b/implementations/tests/tests/test_conditions.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests/test_pullrequest_github.py
+++ b/implementations/tests/tests/test_pullrequest_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import datetime
 import unittest
 import json

--- a/implementations/tests/tests/test_reviews_accepted_github.py
+++ b/implementations/tests/tests/test_reviews_accepted_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests/test_reviews_declined_github.py
+++ b/implementations/tests/tests/test_reviews_declined_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests/test_reviews_github.py
+++ b/implementations/tests/tests/test_reviews_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests/test_utils.py
+++ b/implementations/tests/tests/test_utils.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 from datetime import datetime

--- a/implementations/tests/tests_df/test_code_changes_git.py
+++ b/implementations/tests/tests_df/test_code_changes_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import json
 import unittest
 

--- a/implementations/tests/tests_df/test_code_changes_lines_git.py
+++ b/implementations/tests/tests_df/test_code_changes_lines_git.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 from pandas.testing import assert_frame_equal

--- a/implementations/tests/tests_df/test_commit.py
+++ b/implementations/tests/tests_df/test_commit.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import datetime
 import json
 import unittest

--- a/implementations/tests/tests_df/test_conditions.py
+++ b/implementations/tests/tests_df/test_conditions.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests_df/test_issue_github.py
+++ b/implementations/tests/tests_df/test_issue_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 from datetime import datetime
 import unittest
 import json

--- a/implementations/tests/tests_df/test_issues_closed_github.py
+++ b/implementations/tests/tests_df/test_issues_closed_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 from pandas.util.testing import assert_frame_equal

--- a/implementations/tests/tests_df/test_issues_new_github.py
+++ b/implementations/tests/tests_df/test_issues_new_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 from pandas.util.testing import assert_frame_equal

--- a/implementations/tests/tests_df/test_metric.py
+++ b/implementations/tests/tests_df/test_metric.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import json
 import unittest
 

--- a/implementations/tests/tests_df/test_open_issue_age_github.py
+++ b/implementations/tests/tests_df/test_open_issue_age_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 from datetime import datetime

--- a/implementations/tests/tests_df/test_pullrequest_github.py
+++ b/implementations/tests/tests_df/test_pullrequest_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import datetime
 import json
 import unittest

--- a/implementations/tests/tests_df/test_reviews_accepted_github.py
+++ b/implementations/tests/tests_df/test_reviews_accepted_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests_df/test_reviews_declined_github.py
+++ b/implementations/tests/tests_df/test_reviews_declined_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests_df/test_reviews_duration_github.py
+++ b/implementations/tests/tests_df/test_reviews_duration_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests_df/test_reviews_github.py
+++ b/implementations/tests/tests_df/test_reviews_github.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 

--- a/implementations/tests/tests_df/test_utils.py
+++ b/implementations/tests/tests_df/test_utils.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CHAOSS
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Aniruddha Karajgi <akarajgi0@gmail.com>
+#
+
 import unittest
 import json
 from datetime import datetime


### PR DESCRIPTION
This patch adds a few missing lines of 
documentation, adds licensing to all scripts and 
rearranges a few imports.

@jgbarah, @valeriocos,  please add your details as a contributor wherever you see fit. :)