### PR TITLE
[travis-ci] Remove support for Python 3.4 from travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 


### PR DESCRIPTION
This patch updates the travis.yml file and removes
support for Python 3.4. Python 3.5 and 3.6 are 
currently being supported.

This also decreases build time by about 3-4 minutes.