### PR TITLE
Update New_Contributor_Closing_Issues.md

### DIFF
--- a/metrics/New_Contributor_Closing_Issues.md
+++ b/metrics/New_Contributor_Closing_Issues.md
@@ -1,9 +1,9 @@
 # New Contributors Closing Issues
 
-Question: How many contributors are closing issues for the first time?
+Question: How many contributors are closing issues for the first time in a given project?
 
 ## Description
-This metric is an indication of the volume of contributors who are closing issues for their first time. When a contributor closes an issue for the first time it is some indication of "stickiness" for the individual within a project, especially for contributors who are not also committers.
+This metric is an indication of the volume of contributors who are closing issues for their first time within a given project. When a contributor closes an issue for the first time it is some indication of "stickiness" of the individual within that project, especially for contributors who are not also committers.
 
 ## Objectives
 To know how contributors are moving through the [contributor funnel](https://mikemcquaid.com/2018/08/14/the-open-source-contributor-funnel-why-people-dont-contribute-to-your-open-source-project/) by identifying “closing issues” as a milestone in the contributor journey.
@@ -11,17 +11,18 @@ To know how contributors are moving through the [contributor funnel](https://mik
 ## Implementation
 
 **Aggregators:**
-* Count. Total number of new contributors closing issues on this project for the first time during a given time period.
+* Count. Total number of contributors closing issues on this project for the first time during a given time period.
+* Percentage. Proportion of contributors closing issues on this project *for the first time* during a given time period, computed against *all* contributors having closed issues on this project during the same time period.
 
 **Parameters:**
-* Period of time. Start and finish date of the period. Default: forever.
- Period during which new issue closers are counted.
+* Period of time. Start and finish date of the period during which new issue closers are counted. Default: forever (i.e., the entire observable project lifetime)
 
 ### Filters
 * Exclude reopened issues (optionally, filter if reopened in less than 1 hour)
 
 ### Visualizations
-Table with names of contributors who closed an issue for the first time and when that was
+* Table with names of contributors who closed an issue for the first time and when that was.
+* Timeline showing the time on the x-axis, and the aggregated metric value on the y-axis for fixed consecutive periods of time (e.g. on a monthly basis). This visualisation allows to show how the metric is evolving over time for the considered project.
 
 ### Data Collection Strategies
 Based on the [Issues Closed](https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_Closed.md) and [Contributor](https://github.com/chaoss/wg-common/blob/master/focus-areas/who/contributors.md) definitions, enrich contributors with the date of their first time closing an issue.


### PR DESCRIPTION
I provided some extensions of the metric description (e.g. a second aggregator and a second visualisation) and some minor improvements. Feel free to ignore any of these if you do not agree.
In addition, I have some comments/questions I did not integrate: (1) First of all, I think the metric name "New Contributors Closing Issues" is misleading, since the contributors are not necessarily "New". They may have been there for a long time before they actually closed an issue for the first time. (2) Secondly, this metric seems specific to GitHub Issues, but a very similar metric could also be defined for "Closing Pull Requests". So either the current metric could be generalised to also include closing of pull requests (could be a parameter of the metric), or another metric could be proposed that is basically the same, except that it works on pull requests rather than on issues. (3) Thirdly, I do not see why the filer "exclude reopened issues" needs to be present. Even if an issue has been reopened that was closed by a first-time-issue-closer, it seems strange to not include that specific contributor in the count, just because someone decides to reopen the issue later.