### PR TITLE
Update Issue_Age.md

### DIFF
--- a/metrics/Issue_Age.md
+++ b/metrics/Issue_Age.md
@@ -1,9 +1,9 @@
 # Issue Age
 
-Question: What is the aggregated time that issues have been left open in a project?
+Question: How long have open issues been left open?
 
 ## Description
-This aggregated metric is an indication of how long issues have been left open in the considered time period. If an issue has been closed but re-opened again within that period if will be considered as having remained open since its initial opening date.
+This metric is an indication of how long issues have been left open in the considered time period. If an issue has been closed but re-opened again within that period if will be considered as having remained open since its initial opening date.
 
 ## Objectives
 When the issue age is increasing, identify the oldest open issues in a project to gain insight as to why they have been open for an extended period of time. Additionally, to understand how well maintainers are resolving issues and how quickly issues are resolved. 

--- a/metrics/Issue_Age.md
+++ b/metrics/Issue_Age.md
@@ -1,22 +1,22 @@
 # Issue Age
 
-Question: What is the average time that open issues have been open?
+Question: What is the aggregated time that issues have been left open in a project?
 
 ## Description
-This metric is an indication of how long issues that are currently open have been open. This also includes issues that have been re-opened (counting from their initial open date).
+This aggregated metric is an indication of how long issues have been left open in the considered time period. If an issue has been closed but re-opened again within that period if will be considered as having remained open since its initial opening date.
 
 ## Objectives
-When the issue age is increasing, identify the oldest open issues in a project to gain insight as to why they have been open for an extended period of time. Additionally, to understand how well maintainers are resolving issues and how quickly bugs are resolved. 
+When the issue age is increasing, identify the oldest open issues in a project to gain insight as to why they have been open for an extended period of time. Additionally, to understand how well maintainers are resolving issues and how quickly issues are resolved. 
 
 ## Implementation
 For all open issues, get the date the issue was opened and calculate the number of days to current date.
 
 **Aggregators:**
-* Average. Average age of all currently open issues.
+* Average. Average age of all open issues.
+* Median. Median age of all open issues.
 
 **Parameters:**
-* Period of time. Start and finish date of the period. Default: forever.
- Period during which issues are considered.
+* Period of time. Start and finish date of the period during which open issues are considered. Default: forever (i.e., the entire observable period of the project's issue activity).
 
 ### Filters
 * Module or working group


### PR DESCRIPTION
I made a couple of improvements in the text to make it more clear.
I also have some suggestions and comments that are NOT YET integrated in the text: (1) I do not tend to agree with the proposed "Implementation" description, that does not currently include counting all issues that have been opened AND closed in the considered time period. I would include these as well in the metric. In other words, I do not see a reason to restrict to only those issues that are still open at the end of the considered period. If you want to know the average age that an issue stays open, IMHO you should also include those issues that are already closed and count how long they have stayed open before they were closed.
(2) Always be careful with an "Average" aggregator. Average is only a good aggregator is data is normally distributed, but is misleading for skewed distributions. For such distributions, other aggregators, like for example "Median" will provide more robust results. This is a well-known fact in statistical analysis. This remark is likely to be applicable to any other CHAOSS metric that relies on the use of "Average" as an aggregator.
(3) How does the metric deal with incomplete data? For example, suppose that the issue was opened already before the start date of the considered period, then should I include the issue age as part of the metric? If yes, how? If we do not know when the issue was opened (since it happened before the considered period, also known as left-censoring) then we cannot correctly compute its age. One solution would be to exclude such issues from the aggregation.

Signed-off-by: Tom Mens <tommens@users.noreply.github.com>