### PR TITLE
The classification of commits by tag in Code Changes Lines metric

### DIFF
--- a/metrics/Code_Changes_Lines.md
+++ b/metrics/Code_Changes_Lines.md
@@ -60,13 +60,10 @@ be any line of a source code file, including comments and blank lines.
 * By groups of actors (employer, gender...). Requires actor grouping,
 and likely, actor merging.
 
-* By tags (used in the message of the commits). Requires a structure
-  for the message of commits.
-
-#### Tag in message of commit
-
-This tag can be use in a open-source project to communicate to every
-contributors if the commit is, for example, a fix for a bug or a improvement of a feature.
+* By [tags](https://www.odoo.com/documentation/13.0/reference/guidelines.html#tag-and-module-name) (used in the message of the commits).
+Requires a structure for the message of commits.
+This tag can be used in an open-source project to communicate to every contributors
+if the commit is, for example, a fix for a bug or an improvement of a feature.
 
 ## Visualizations
 
@@ -119,3 +116,4 @@ __Mandatory parameters:__
 
 ## Resources
 
+* https://www.odoo.com/documentation/13.0/reference/guidelines.html#tag-and-module-name

--- a/metrics/Code_Changes_Lines.md
+++ b/metrics/Code_Changes_Lines.md
@@ -52,7 +52,7 @@ be any line of a source code file, including comments and blank lines.
     - Whitespace 
 
 
-## Filters
+### Filters
 
 * By actors (author, committer). Requires actor merging
 (merging ids corresponding to the same author).
@@ -60,6 +60,13 @@ be any line of a source code file, including comments and blank lines.
 * By groups of actors (employer, gender...). Requires actor grouping,
 and likely, actor merging.
 
+* By tags (used in the message of the commits). Requires a structure
+  for the message of commits.
+
+#### Tag in message of commit
+
+This tag can be use in a open-source project to communicate to every
+contributors if the commit is, for example, a fix for a bug or a improvement of a feature.
 
 ## Visualizations
 


### PR DESCRIPTION
In a project, we can have a guideline for the writing of message of
commits. For example, if code changes in the commit are for a bug
fix. The message of this commit can be :
"[FIX] add path into sys.path to include correctly scripts for metrics"

With this "[FIX]" tag, we can classify the commits by tag and have all
commits corresponding to a fix.

Signed-off-by: Xavier Bol <xavier.bol@student.umons.ac.be>