### PR TITLE
Fix References section in Code_Changes_Lines.md

### DIFF
--- a/metrics/Code_Changes_Lines.md
+++ b/metrics/Code_Changes_Lines.md
@@ -110,5 +110,5 @@ __Mandatory parameters:__
     those which merge a branch, and in some cases are not considered as
     reflecting a coding activity
 
-## Resources
+## References
 


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" so as to adhere to the standard template.