### PR TITLE
Update Reviews_Accepted.md

### DIFF
--- a/metrics/Reviews_Accepted.md
+++ b/metrics/Reviews_Accepted.md
@@ -1,6 +1,6 @@
 # Reviews Accepted
 
-**Question:** How many accepted reviews are present in a code change?
+Question: How many accepted reviews are present in a code change?
 
 ## Description
 
@@ -151,5 +151,5 @@ None.
 
 
 
-## Resources
+## References
  


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" and un-bolds the "Question" so as to adhere to the standard template.