### PR TITLE
Update Reviews_Declined.md

### DIFF
--- a/metrics/Reviews_Declined.md
+++ b/metrics/Reviews_Declined.md
@@ -1,6 +1,6 @@
 # Reviews Declined
 
-**Question:** What reviews of code changes ended up declining the change during a certain period?
+Question: What reviews of code changes ended up declining the change during a certain period?
 
 
 ## Description
@@ -99,5 +99,5 @@ abandoned", as long as they propose changes to source code files.
 __Mandatory parameters:__
 None.
 
-## Resources
+## References
 


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" and un-bolds the "Question" so as to adhere to the standard template.