### PR TITLE
Update Reviews_Duration.md

### DIFF
--- a/metrics/Reviews_Duration.md
+++ b/metrics/Reviews_Duration.md
@@ -1,6 +1,6 @@
 # Reviews Duration
 
-**Question:** What is the duration of time between the moment a code review starts and the moment it is accepted?
+Question: What is the duration of time between the moment a code review starts and the moment it is accepted?
 
 
 ## Description
@@ -111,5 +111,5 @@ __Mandatory parameters:__
 
 None.
 
-## Resources
+## References
 


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" and un-bolds the "Question" so as to adhere to the standard template.