### PR TITLE
Update Reviews.md

### DIFF
--- a/metrics/Reviews.md
+++ b/metrics/Reviews.md
@@ -105,4 +105,4 @@ The date of the review can be defined (for considering it in a period or not)
 as the date in which the code review was started by submitting a
 patchset for review.
 
-## Resources
+## References


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" so as to adhere to the standard template.