### PR TITLE
Update Issues_Active.md

### DIFF
--- a/metrics/Issues_Active.md
+++ b/metrics/Issues_Active.md
@@ -97,4 +97,4 @@ In the case of Bugzilla, active issues are defined as "bug reports
 which get a comment, a change in state, a change in assigned
 person, or are closed".
 
-## Resources
+## References


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" so as to adhere to the standard template.