### PR TITLE
Update Issues_Closed.md

### DIFF
--- a/metrics/Issues_Closed.md
+++ b/metrics/Issues_Closed.md
@@ -109,5 +109,5 @@ In the case of Jira, active issues are defined as "issues that change to the clo
 
 In the case of Bugzilla, active issues are defined as "bug reports that change to the closed state".
 
-## Resources
+## References
 


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" so as to adhere to the standard template.