### PR TITLE
Update Issue_Age.md

### DIFF
--- a/metrics/Issue_Age.md
+++ b/metrics/Issue_Age.md
@@ -37,6 +37,6 @@ For all open issues, get the date the issue was opened and calculate the number 
 
 ### Data Collection Strategies 
 
-For specific descriptions of collecting data about closed issues, please refer to the [corresponding section of Issues Closed](./Issues_Closed.md#data-collection-strategies).
+For specific descriptions of collecting data about closed issues, please refer to the [corresponding section of Issues New](./Issues_New.md#data-collection-strategies).
 
-## Resources
+## References


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" so as to adhere to the standard template.