### PR TITLE
Update Issue_Resolution_Duration.md

### DIFF
--- a/metrics/Issue_Resolution_Duration.md
+++ b/metrics/Issue_Resolution_Duration.md
@@ -52,6 +52,6 @@ For each closed issue:
 For specific descriptions of collecting data about closed issues, please refer to the [corresponding section of Issues Closed](./Issues_Closed.md#data-collection-strategies).
 
 
-### Resources
+### References
 * None.
 


### PR DESCRIPTION
This patch renames the incorrectly labeled "Resources" section in the metric
above to "References" so as to adhere to the standard template.