### PR TITLE
Add link to GrimoireLab implementation of Issue Response Time

### DIFF
--- a/metrics/Issue_Response_Time.md
+++ b/metrics/Issue_Response_Time.md
@@ -29,7 +29,7 @@ Learn about the responsiveness of an open source community.
 ![Example visualization from GrimoireLab](images/issue_response_duration_grimoirelab.png)
 
 ### Tools Providing the Metric 
-* GrimoireLab
+* [GrimoireLab](https://chaoss.github.io/grimoirelab-sigils/panels/github-issues-efficiency/)
 * [Augur](http://augur.osshealth.io/api_docs/#api-Evolution-Issue_Response_Time_Repo_)
 
 ### Data Collection Strategies


### PR DESCRIPTION
This patch adds a relevant link to the GrimoireLab documentation and implementation of the Issue Response Time metric.