### PR TITLE
Add "reactions" as parameter on Issues_Closed

### DIFF
--- a/metrics/Issues_Closed.md
+++ b/metrics/Issues_Closed.md
@@ -40,6 +40,7 @@ used to track volume of coding activity.
 **Aggregators:**
 * Count. Total number of active issues during the period.
 * Ratio. Ratio of active issues over total number of issues during that period.
+* Reactions. Number of "thumb-ups" or other reactions on issues.
 
 **Parameters:**
 * Period of time. Start and finish date of the period during which issues are considered. Default: forever.  


### PR DESCRIPTION
Reactions like "thumbs-up" on issues can indicate how much the community cares about issues.

At CLS / ATO 2020, John Coghlan said he'd be interested in understanding how much the community cares about the issues they close.