### PR TITLE
Add reactions to change requests and issues

### DIFF
--- a/metrics/Change_Requests.md
+++ b/metrics/Change_Requests.md
@@ -31,6 +31,7 @@ or in some contexts "changesets" in the case of Gerrit.
 
 **Aggregators:**
 * Count. Total number of change requests during the period.
+* Reactions. Number of "thumb-ups" or other reactions on issues.
 
 **Parameters:**
 

--- a/metrics/Change_Requests_Accepted.md
+++ b/metrics/Change_Requests_Accepted.md
@@ -33,6 +33,7 @@ corresponds to a single commit.
 **Aggregators:**
 * Count. Total number of accepted change requests during the period.
 * Ratio. Ratio of accepted change requests over total number of change requests during that period.
+* Reactions. Number of "thumb-ups" or other reactions on issues.
 
 **Parameters:**
 * Period of time. Start and finish date of the period during which accepted change requests are considered. Default: forever.  

--- a/metrics/Change_Requests_Declined.md
+++ b/metrics/Change_Requests_Declined.md
@@ -33,6 +33,7 @@ declined change requests in this system.
 **Aggregators**:
 * Count. Total number of declined change requests during the period.
 * Ratio. Ratio of declined change requests over the total number of change requests during that period.
+* Reactions. Number of "thumb-ups" or other reactions on issues.
 
 **Parameters:**
 * Period of time. Start and finish date of the period during which declined change requests are considered. Default: forever.

--- a/metrics/Issues_Active.md
+++ b/metrics/Issues_Active.md
@@ -30,6 +30,7 @@ the action of closing an issue, is considered as a sign of activity.
 **Aggregators:**
 * Count. Total number of active issues during the period.
 * Ratio. Ratio of active issues over total number of issues during that period.
+* Reactions. Number of "thumb-ups" or other reactions on issues.
 
 **Parameters:**
 * Period of time. Start and finish date of the period during which issues are considered. Default: forever.

--- a/metrics/Issues_New.md
+++ b/metrics/Issues_New.md
@@ -56,6 +56,7 @@ this metric is not the only one that should be used to track volume of coding ac
 **Aggregators:**
 * Count. Total number of new issues during the period.
 * Ratio. Ratio of new issues over total number of issues during that period.
+* Reactions. Number of "thumb-ups" or other reactions on issues.
 
 **Parameters:**
 * Period of time. Start and finish date of the period during which issues are considered. Default: forever.  


### PR DESCRIPTION
#378 was the first, this PR adds the new filter to more metrics.

The idea is that we want to understand the impact of our work as it matters to community members. We use *reactions* on an issue or change request as an indicator for how much people care about them. We then use the reactions as a filter or aggregator.