### PR TITLE
Standardize & remove extra content from focus-area READMEs 

### DIFF
--- a/focus-areas/code-development-activity/README.md
+++ b/focus-areas/code-development-activity/README.md
@@ -1,24 +1,9 @@
-# Focus Area: Code Development Activity
+# Code Development Activity
 
-Goal: Learn about the types and frequency of activities involved in developing code.
+**Goal:** Learn about the types and frequency of activities involved in developing code.
 
 Name | Question
 --- | ---
 [Branch Lifecycle](branch-lifecycle.md)| How do projects manage the lifecycle of their version control branches?
 [Code Changes](code-changes.md) | What changes were made to the source code during a specified period?
 [Code Changes Lines](code-changes-lines.md) | What is the sum of the number of lines touched (lines added plus lines removed) in all changes to the source code during a certain period?
-
-**Disclaimer:**
-The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
-
-**Tooling:**
-The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
-
-**Background:**
-The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
-
-**How to contribute:**
-- To advance the document, fork the repo, make your changes and create a pull request.
-- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
-
-[issue]: https://github.com/chaoss/evolution/issues

--- a/focus-areas/code-development-efficiency/README.md
+++ b/focus-areas/code-development-efficiency/README.md
@@ -1,6 +1,6 @@
-# Focus Area: Code Development Efficiency
+# Code Development Efficiency
 
-Goal:  Learning how efficiently activities around code development get resolved.
+**Goal:** Learning how efficiently activities around code development get resolved.
 
 Name | Question
 --- | ---
@@ -8,18 +8,3 @@ Name | Question
 [Change Request Acceptance Ratio](change-request-acceptance-ratio.md) | What is the ratio of change requests accepted to change requests closed without being merged?
 [Change Requests Declined](change-requests-declined.md) | What change requests ended up being declined during a certain period?
 [Change Requests Duration](change-requests-duration.md)| What is the duration of time between the moment a change request starts and the moment it is accepted or closed?
-
-**Disclaimer:**
-The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
-
-**Tooling:**
-The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
-
-**Background:**
-The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
-
-**How to contribute:**
-- To advance the document, fork the repo, make your changes and create a pull request.
-- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
-
-[issue]: https://github.com/chaoss/evolution/issues

--- a/focus-areas/code-development-process-quality/README.md
+++ b/focus-areas/code-development-process-quality/README.md
@@ -1,22 +1,7 @@
-# Focus Area: Code Development Process Quality
+# Code Development Process Quality
 
-Goal: Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
+**Goal:** Learning about the processes to improve/review quality that are used (for example: testing, code review, tagging issues, tagging a release, time to response, CII Badging).
 
 Name | Question
 --- | ---
 [Change Requests](change-requests.md) | What new change requests to the source code occurred during a certain period?
-
-**Disclaimer:**
-The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
-
-**Tooling:**
-The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
-
-**Background:**
-The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
-
-**How to contribute:**
-- To advance the document, fork the repo, make your changes and create a pull request.
-- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
-
-[issue]: https://github.com/chaoss/evolution/issues

--- a/focus-areas/community-growth/README.md
+++ b/focus-areas/community-growth/README.md
@@ -1,24 +1,9 @@
-## Community Growth
+# Community Growth
 
-Goal: Identify the size of the project community and whether it is growing, shrinking, or staying the same.
+**Goal:** Identify the size of the project community and whether it is growing, shrinking, or staying the same.
 
-Metric | Question
+Name | Question
 --- | ---
 [New Contributors](new-contributors.md) | What is the overall number of new contributors?
 [New Contributors Closing Issues](new-contributor-closing-issues.md) | How many contributors are closing issues for the first time?
 [Inactive Contributors](inactive-contributors.md) | How many Contributors have gone inactive over a specific period of time?
-
-**Disclaimer:**
-The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Growth-Maturity-Decline.
-
-**Tooling:**
-The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
-
-**Background:**
-The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
-
-**How to contribute:**
-- To advance the document, fork the repo, make your changes and create a pull request.
-- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
-
-[issue]: https://github.com/chaoss/wg-gmd/issues

--- a/focus-areas/issue-resolution/README.md
+++ b/focus-areas/issue-resolution/README.md
@@ -1,6 +1,6 @@
-# Focus Area: Issue Resolution
+# Issue Resolution
 
-Goal: Identify how effective the community is at addressing issues identified by community participants.
+**Goal:** Identify how effective the community is at addressing issues identified by community participants.
 
 Name | Question
 --- | ---
@@ -10,18 +10,3 @@ Name | Question
 [Issue Age](issue-age.md) | How long have open issues been left open?
 [Issue Response Time](issue-response-time.md) | How much time passes between the opening of an issue and a response in the issue thread from another contributor?
 [Issue Resolution Duration](issue-resolution-duration.md) | How long does it take for an issue to be closed?
-
-**Disclaimer:**
-The name/question pairs listed are not meant to represent a fully comprehensive list. It is expected that this list will evolve as people have insights and thoughts about the name/question pairs that comprise Evolution.
-
-**Tooling:**
-The name/question pairs are intended to be a starting point for CHAOSS-related software. It is expected that this list will evolve based on the ability (or inability) of software to successfully implement the specific name/question pairs.
-
-**Background:**
-The name/question pairs have been identified based CHAOSS-related outreach activities. We thank everyone who participated.
-
-**How to contribute:**
-- To advance the document, fork the repo, make your changes and create a pull request.
-- To ask questions or make comments open an [issue on GitHub][issue] or join the discussion on the [mailing list or weekly calls](https://chaoss.community/participate/).
-
-[issue]: https://github.com/chaoss/evolution/issues


### PR DESCRIPTION
The changes are made to follow the [template](https://github.com/chaoss/governance/blob/master/templates/focus-areas.md#template-for-wgfocus-areasfocus-area-namereadmemd) for focus-area READMEs.

Signed-off-by: Yash Prakash <yash2002109@gmail.com>