### PR TITLE
Fix name: "Issues New"

### DIFF
--- a/focus-areas/issue-resolution/issues-new.md
+++ b/focus-areas/issue-resolution/issues-new.md
@@ -1,4 +1,4 @@
-# New Issues
+# Issues New
 
 Question: How many new issues are created during a certain period? 
 


### PR DESCRIPTION
The naming convention in the Evolution WG is to name 
the thing first and then what we learn about it. In the
Focus Area, the name is correct "Issues New" and this
commit fixes the heading on the metric definition to be
the same.

Signed-off-by: Georg J.P. Link <linkgeorg@gmail.com>