### PR TITLE
Changing metric name to align our use of time related terms.

### DIFF
--- a/focus-areas/issue-resolution/issue-resolution-duration.md
+++ b/focus-areas/issue-resolution/issue-resolution-duration.md
@@ -1,4 +1,4 @@
-# Issue Resolution Duration
+# Time to Issue Resolution
 
 Question: How long does it take for an issue to be closed?
 


### PR DESCRIPTION
Part of a CHAOSS Level name consistency effort. Closes issue #459 