### PR TITLE
Update change-requests-declined.md

### DIFF
--- a/focus-areas/code-development-efficiency/change-requests-declined.md
+++ b/focus-areas/code-development-efficiency/change-requests-declined.md
@@ -4,94 +4,48 @@ Question: What change requestsended up being declined during a certain period?
 
 ## Description
 
-Change requests are defined as in [Change Requests](https://chaoss.community/metric-change-requests/).
-Declined change requests are those that are finally closed without
-being merged into the code base of the project.
-
-For example, in GitHub when a pull request is closed without
-merging, and the commits referenced in it cannot be found
-in the git repository, it can be considered to be declined
-(but see detailed discussion below). The same can be said of
-GitLab merge requests. In the case of Gerrit, code reviews
-can be formally "abandoned", which is the way of detecting
-declined change requests in this system.
-
+Change requests are defined as in [Change Requests](https://chaoss.community/metric-change-requests/). Declined change requests are those that are finally closed without being merged into the code base of the project. For example, in GitHub when a pull request is closed without merging, and the commits referenced in it cannot be found in the git repository, it can be considered to be declined (but see detailed discussion below). The same can be said of GitLab merge requests. In the case of Gerrit, code reviews can be formally "abandoned", which is the way of detecting declined change requests in this system.
 
 ## Objectives
-
-* Volume of coding activity.
-    Declined change requests are a proxy for the activity in a project.
-    By counting declined change requests in the set of repositories corresponding
-    to a project, you can have an idea of the overall coding activity in
-    that project that did not lead to actual changes.
-    Of course, this metric is not the only one that should be
-    used to track volume of coding activity.
+Declined change requests are a proxy for the activity in a project. By counting declined change requests in the set of repositories corresponding to a project, you can have an idea of the overall coding activity in that project that did not lead to actual changes. Of course, this metric is not the only one that should be used to track volume of coding activity.
 
 ## Implementation
-*The usage and dissemination of health metrics may lead to privacy violations. Organizations may be exposed to risks. These risks may flow from compliance with the GDPR in the EU, with state law in the US, or with other law. There may also be contractual risks flowing from terms of service for data providers such as GitHub and GitLab. The usage of metrics must be examined for risk and potential data ethics problems. Please see [CHAOSS Data Ethics document](https://github.com/chaoss/community/blob/main/data-use-statement.md) for additional guidance.*
 
-**Aggregators**:
+Potential aggregators include: 
 * Count. Total number of declined change requests during the period.
 * Ratio. Ratio of declined change requests over the total number of change requests during that period.
 
-**Parameters:**
+Potential parameters include: 
 * Period of time. Start and finish date of the period during which declined change requests are considered. Default: forever.
-* Criteria for source code. Algorithm. Default: all files are source code.
-    If we focus on source code, we need a criterion to decide
-    whether a file belongs to the source code or not.
-
+* Criteria for source code. Algorithm. Default: all files are source code. If we focus on source code, we need a criterion to decide whether a file belongs to the source code or not.
 
 ### Filters
 
 * By actors (submitter, reviewer, merger). Requires merging identities corresponding to the same actor.
 * By groups of actors (employer, gender... for each of the actors). Requires actor grouping, and likely, actor merging.
-
-
-### Visualizations
-
 * Count per period over time
 * Ratio per period over time
-
-These could be grouped (per actor type, or per group of actors) by applying the filters,
-and could be represented as bar charts, with time running in the X axis.
-Each bar would represent declined change requests during a certain period (e.g., a month).
-
 
 ### Data Collection Strategies
 
 **Specific description: GitHub**
 
-In the case of GitHub, declined change requests are defined as "pull requests
-that are closed with their changes not being included in the git repository",
-as long as it proposes changes to source code files.
+In the case of GitHub, declined change requests are defined as "pull requests that are closed with their changes not being included in the git repository", as long as it proposes changes to source code files.
 
-See the discussion in the specific description for GitHub in
-[Change Requests Accepted](https://chaoss.community/metric-change-requests-accepted/), since it applies here as well.
+See the discussion in the specific description for GitHub in [Change Requests Accepted](https://chaoss.community/metric-change-requests-accepted/), since it applies here as well.
 
 Mandatory parameters (for GitHub):
 
-* Heuristic for detecting declined change requests, telling apart
-  those cases where the change request was closed, but the
-  changes were included in the git repository manually.
-  Default: None.
+* Heuristic for detecting declined change requests, telling apart those cases where the change request was closed, but the changes were included in the git repository manually. Default: None.
 
 **Specific description: GitLab**
 
-In the case of GitLab, declined reviews are defined as "merge requests
-that are closed with their changes not being included in the git repository",
-as long as it proposes changes to source code files.
+In the case of GitLab, declined reviews are defined as "merge requests that are closed with their changes not being included in the git repository", as long as it proposes changes to source code files.
 
 Mandatory parameters (for GitLab):
 
-* Heuristic for detecting declined change requests, telling apart
-  those cases where the merge request was closed, but the
-  changes were included in the git repository manually. Default: None.
+* Heuristic for detecting declined change requests, telling apart those cases where the merge request was closed, but the changes were included in the git repository manually. Default: None.
 
 **Specific description: Gerrit**
 
-In the case of Gerrit, declined change requests are defined as "changesets
-abandoned", as long as they propose changes to source code files.
-
-Mandatory parameters (for Gerrit): None.
-
-## References
+In the case of Gerrit, declined change requests are defined as "changesets abandoned", as long as they propose changes to source code files.


### PR DESCRIPTION
Signed-off-by: Matt Germonprez <germonprez@gmail.com>

 Removal of the privacy statement in favor of distributing the privacy statement via wordpress to ensure consistency across all metrics. 

Also some edits to improve the readability of the metric.