### PR TITLE
Add Filter by Label 

### DIFF
--- a/focus-areas/issue-resolution/issues-closed.md
+++ b/focus-areas/issue-resolution/issues-closed.md
@@ -61,6 +61,7 @@ In the case of Bugzilla, closed issues are defined as "bug reports that change t
 
 *   By actors (submitter, commenter, closer). Requires merging identities corresponding to the same author.
 *   By groups of actors (employer, gender... for each of the actors). Requires actor grouping, and likely, actor merging.
+*   By label (bug, security, feature). Requires consistent label application by the project.
 
 ### Visualizations
 


### PR DESCRIPTION
Updated this metric to add a Filter option to filter by label. This will be referred to in the new Demonstrating Value Practitioner Guide, but it's also a good filter to have for projects that use labels.